### PR TITLE
docs: add JavaDoc to FizzBuzz implementation classes

### DIFF
--- a/core/src/main/java/it/robfrank/exercises/fizzbuzz/FizzBuzz.java
+++ b/core/src/main/java/it/robfrank/exercises/fizzbuzz/FizzBuzz.java
@@ -18,12 +18,32 @@ package it.robfrank.exercises.fizzbuzz;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Basic implementation of the FizzBuzz game that processes numbers according to standard rules:
+ * - "fizzbuzz" for numbers divisible by both 3 and 15
+ * - "fizz" for numbers divisible by 3
+ * - "buzz" for numbers divisible by 5
+ * - the number itself for all other cases
+ */
 public class FizzBuzz {
 
+  /**
+   * Processes a stream of integers and applies FizzBuzz rules to each number.
+   *
+   * @param numbers a stream of integers to be processed
+   * @return a string with space-separated results of applying FizzBuzz rules to each number
+   */
   public String execute(Stream<Integer> numbers) {
     return numbers.map(this::execute).collect(Collectors.joining(" "));
   }
 
+  /**
+   * Applies FizzBuzz rules to a single integer.
+   *
+   * @param number the integer to be processed
+   * @return "fizzbuzz" if number is divisible by 15, "fizz" if divisible by 3,
+   *         "buzz" if divisible by 5, or the number as a string otherwise
+   */
   private String execute(Integer number) {
     return switch (number) {
       case Integer n when (n % 15 == 0) -> "fizzbuzz";

--- a/core/src/main/java/it/robfrank/exercises/fizzbuzz/FizzBuzzMain.java
+++ b/core/src/main/java/it/robfrank/exercises/fizzbuzz/FizzBuzzMain.java
@@ -20,17 +20,23 @@ import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Main entry point for the FizzBuzz application.
+ * Demonstrates the use of RuleBasedFizzBuzzer with custom rules configuration.
+ */
 public class FizzBuzzMain {
 
-  //            static java.util.logging.Logger logger = LogManager.getLogManager().getLogger(FizzBuzzMain.class.getName());
-
-  //          static Log log = LogFactory.getLog(FizzBuzzMain.class);
-
+  /** Logger for the application */
   static Logger slf4jLogger = LoggerFactory.getLogger(FizzBuzzMain.class);
 
+  /**
+   * Executes the FizzBuzz program with a configurable rule-based implementation.
+   * Takes a range limit as a command-line argument and processes numbers from 1 to that limit.
+   *
+   * @param args command line arguments - args[0] should contain the upper limit for the range of numbers
+   */
   public static void main(String[] args) {
     Integer range = Integer.valueOf(args[0]);
-    //        System.out.println("range = " + range);
     slf4jLogger.info("range = {}", range);
 
     RuleBasedFizzBuzzer configurableFizzBuzzer = RuleBasedFizzBuzzer.builder()
@@ -46,7 +52,6 @@ public class FizzBuzzMain {
       .build();
 
     String fizzBuzzerized = configurableFizzBuzzer.fizzBuzzerize(IntStream.rangeClosed(1, range).boxed());
-    //        System.out.println("fizzBuzzrized = " + fizzBuzzerized);
     slf4jLogger.info("fizzBuzzrized = {}", fizzBuzzerized);
   }
 }

--- a/core/src/main/java/it/robfrank/exercises/fizzbuzz/FizzBuzzRule.java
+++ b/core/src/main/java/it/robfrank/exercises/fizzbuzz/FizzBuzzRule.java
@@ -18,31 +18,71 @@ package it.robfrank.exercises.fizzbuzz;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Represents a rule in the FizzBuzz game that determines when a specific transformation
+ * should be applied to a number.
+ * <p>
+ * Each rule consists of:
+ * - A condition that determines when the rule applies
+ * - A mapper function that transforms the number to a string
+ * <p>
+ * This class implements both Predicate and Function interfaces to facilitate
+ * rule checking and application.
+ */
 public final class FizzBuzzRule implements Predicate<Integer>, Function<Integer, String> {
 
-  //        private static Logger logger = LogManager.getLogManager().getLogger(FizzBuzzRule.class.getName());
+  /** The condition that determines when this rule applies */
   private final Predicate<Integer> condition;
+
+  /** The transformation to apply when the condition is met */
   private final Function<Integer, String> mapper;
 
+  /**
+   * Private constructor used by the builder.
+   *
+   * @param condition the predicate that determines when this rule applies
+   * @param mapper the function that transforms the number to a string
+   */
   private FizzBuzzRule(Predicate<Integer> condition, Function<Integer, String> mapper) {
     this.condition = condition;
     this.mapper = mapper;
   }
 
+  /**
+   * Creates a new FizzBuzzRule builder.
+   *
+   * @return a new FizzBuzzRuleBuilder instance
+   */
   public static FizzBuzzRuleBuilder builder() {
     return new FizzBuzzRuleBuilder();
   }
 
+  /**
+   * Tests if this rule applies to the given number.
+   *
+   * @param number the number to test
+   * @return true if the rule applies, false otherwise
+   */
   @Override
   public boolean test(Integer number) {
     return condition.test(number);
   }
 
+  /**
+   * Transforms the number according to this rule.
+   *
+   * @param number the number to transform
+   * @return the transformed string
+   */
   @Override
   public String apply(Integer number) {
     return mapper.apply(number);
   }
 
+  /**
+   * Builder class for creating FizzBuzzRule instances.
+   * Follows the builder pattern to provide a fluent API for rule construction.
+   */
   public static final class FizzBuzzRuleBuilder {
 
     private Predicate<Integer> condition;
@@ -50,16 +90,33 @@ public final class FizzBuzzRule implements Predicate<Integer>, Function<Integer,
 
     private FizzBuzzRuleBuilder() {}
 
+    /**
+     * Sets the condition for the rule.
+     *
+     * @param condition the predicate that determines when the rule applies
+     * @return this builder instance for method chaining
+     */
     public FizzBuzzRuleBuilder withCondition(Predicate<Integer> condition) {
       this.condition = condition;
       return this;
     }
 
+    /**
+     * Sets the transformation function for the rule.
+     *
+     * @param mapper the function that transforms the number to a string
+     * @return this builder instance for method chaining
+     */
     public FizzBuzzRuleBuilder withMapper(Function<Integer, String> mapper) {
       this.mapper = mapper;
       return this;
     }
 
+    /**
+     * Builds a new FizzBuzzRule with the configured condition and mapper.
+     *
+     * @return a new FizzBuzzRule instance
+     */
     public FizzBuzzRule build() {
       return new FizzBuzzRule(condition, mapper);
     }

--- a/core/src/main/java/it/robfrank/exercises/fizzbuzz/RobfrankFizzBuzz.java
+++ b/core/src/main/java/it/robfrank/exercises/fizzbuzz/RobfrankFizzBuzz.java
@@ -18,12 +18,43 @@ package it.robfrank.exercises.fizzbuzz;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Extended implementation of the FizzBuzz game with a custom rule.
+ * <p>
+ * This implementation follows standard FizzBuzz rules but adds an additional rule:
+ * - "robfrank" for numbers that contain the digit 3
+ * - "fizzbuzz" for numbers divisible by both 3 and 15
+ * - "fizz" for numbers divisible by 3
+ * - "buzz" for numbers divisible by 5
+ * - the number itself for all other cases
+ * <p>
+ * The rules are evaluated in the order listed above, so the "robfrank" rule takes
+ * precedence over the other rules.
+ */
 public class RobfrankFizzBuzz {
 
+  /**
+   * Processes a stream of integers and applies extended FizzBuzz rules to each number.
+   *
+   * @param numbers a stream of integers to be processed
+   * @return a string with space-separated results of applying FizzBuzz rules to each number
+   */
   public String execute(Stream<Integer> numbers) {
     return numbers.map(this::execute).collect(Collectors.joining(" "));
   }
 
+  /**
+   * Applies extended FizzBuzz rules to a single integer.
+   * Rules are evaluated in the following order:
+   * 1. If the number contains the digit 3, return "robfrank"
+   * 2. If the number is divisible by 15, return "fizzbuzz"
+   * 3. If the number is divisible by 3, return "fizz"
+   * 4. If the number is divisible by 5, return "buzz"
+   * 5. Otherwise, return the number as a string
+   *
+   * @param number the integer to be processed
+   * @return the result of applying the rules to the number
+   */
   private String execute(Integer number) {
     return switch (number) {
       case Integer n when n.toString().contains("3") -> "robfrank";

--- a/core/src/main/java/it/robfrank/exercises/fizzbuzz/RuleBasedFizzBuzzer.java
+++ b/core/src/main/java/it/robfrank/exercises/fizzbuzz/RuleBasedFizzBuzzer.java
@@ -20,28 +20,67 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * A configurable implementation of FizzBuzz that applies rules in a specified order.
+ * <p>
+ * This class allows for flexible configuration of FizzBuzz rules through a builder pattern.
+ * Rules are evaluated in the order they are added, and the first matching rule is applied.
+ * If no rule matches, a default rule is applied.
+ */
 public final class RuleBasedFizzBuzzer {
 
+  /** The list of rules to apply in order */
   private final List<FizzBuzzRule> rules;
+
+  /** The default rule to apply when no other rule matches */
   private final FizzBuzzRule defaultRule;
 
+  /**
+   * Private constructor used by the builder.
+   *
+   * @param rules the list of rules to apply in order
+   * @param defaultRule the default rule to apply when no other rule matches
+   */
   private RuleBasedFizzBuzzer(List<FizzBuzzRule> rules, FizzBuzzRule defaultRule) {
     this.rules = rules;
     this.defaultRule = defaultRule;
   }
 
+  /**
+   * Creates a new RuleBasedFizzBuzzer builder.
+   *
+   * @return a new RuleBasedFizzBuzzerBuilder instance
+   */
   public static RuleBasedFizzBuzzerBuilder builder() {
     return new RuleBasedFizzBuzzerBuilder();
   }
 
+  /**
+   * Processes a stream of integers by applying FizzBuzz rules to each number.
+   *
+   * @param numbers a stream of integers to be processed
+   * @return a space-separated string with the results of applying rules to each number
+   */
   public String fizzBuzzerize(Stream<Integer> numbers) {
     return numbers.map(this::fizzBuzzerize).collect(Collectors.joining(" "));
   }
 
+  /**
+   * Applies FizzBuzz rules to a single integer.
+   * Rules are evaluated in the order they were added to the builder.
+   * If no rule matches, the default rule is applied.
+   *
+   * @param number the integer to be processed
+   * @return the result of applying the first matching rule, or the default rule if none match
+   */
   public String fizzBuzzerize(Integer number) {
     return rules.stream().filter(p -> p.test(number)).map(f -> f.apply(number)).findFirst().orElse(defaultRule.apply(number));
   }
 
+  /**
+   * Builder class for creating RuleBasedFizzBuzzer instances.
+   * Follows the builder pattern to provide a fluent API for configuration.
+   */
   public static final class RuleBasedFizzBuzzerBuilder {
 
     private final List<FizzBuzzRule> rules = new ArrayList<>();
@@ -49,20 +88,43 @@ public final class RuleBasedFizzBuzzer {
 
     private RuleBasedFizzBuzzerBuilder() {}
 
+    /**
+     * Adds multiple rules to the builder.
+     *
+     * @param rules a list of FizzBuzzRule instances to add
+     * @return this builder instance for method chaining
+     */
     public RuleBasedFizzBuzzerBuilder withRules(List<FizzBuzzRule> rules) {
       this.rules.addAll(rules);
       return this;
     }
 
+    /**
+     * Adds a single rule to the builder.
+     *
+     * @param rule a FizzBuzzRule instance to add
+     * @return this builder instance for method chaining
+     */
     public RuleBasedFizzBuzzerBuilder withRule(FizzBuzzRule rule) {
       this.rules.add(rule);
       return this;
     }
 
+    /**
+     * Builds a new RuleBasedFizzBuzzer with the configured rules and default rule.
+     *
+     * @return a new RuleBasedFizzBuzzer instance
+     */
     public RuleBasedFizzBuzzer build() {
       return new RuleBasedFizzBuzzer(rules, defaultRule);
     }
 
+    /**
+     * Sets the default rule to apply when no other rule matches.
+     *
+     * @param defaultRule the default FizzBuzzRule to use
+     * @return this builder instance for method chaining
+     */
     public RuleBasedFizzBuzzerBuilder withDefaultRule(FizzBuzzRule defaultRule) {
       this.defaultRule = defaultRule;
       return this;


### PR DESCRIPTION
Added comprehensive JavaDoc comments to all core FizzBuzz implementation classes:
- FizzBuzz
- FizzBuzzMain
- FizzBuzzRule
- RobfrankFizzBuzz
- RuleBasedFizzBuzzer

This improves code documentation and makes the purpose and behavior of each class and method clearer for developers working with the codebase. Also improved code formatting in RuleBasedFizzBuzzer.

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>